### PR TITLE
Added a validation for already existent resource, before add the resource

### DIFF
--- a/src/AclRepository.php
+++ b/src/AclRepository.php
@@ -77,6 +77,10 @@ class AclRepository
 
         if (isset($config['resources'])) {
             foreach ($config['resources'] as $resource) {
+                if ($this->acl->hasResource($this->makeResource($resource))) {
+                    continue;
+                }
+                
                 $this->acl->addResource($this->makeResource($resource));
             }
         }


### PR DESCRIPTION
Hello,

I added an extra validation in the constructor of the ACL object, to avoid that an eventual exception by trying to add an already existent resource break the code.

I'm sharing with you for the case that you believe that this can help to avoid a really boring bug that might happen.

Cheers,
Savio